### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,7 +24,7 @@
 			<hr>
 			{{ $currentNode := . }}
 			{{ range .Site.Menus.social }}
-			<a class="nav-item{{if or ($currentNode.IsMenuCurrent "social" .) ($currentNode.HasMenuCurrent "social" .) }} active{{end}}" href="{{.URL}}">{{ .Name}}</a>
+			<a class="nav-item{{if or ($currentNode.IsMenuCurrent "social" .) ($currentNode.HasMenuCurrent "social" .) }} active{{end}}" href="{{.URL}}" rel="me">{{ .Name}}</a>
 			{{end}}
 		</div>
 


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.