### PR TITLE
Adding the possibility of removing the green and blue buttons

### DIFF
--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -4,7 +4,7 @@
 	<div class="wrapper">
 		<h1>{{ .Site.Params.hero.herotitle }}</h1>
 		<p>{{ .Site.Params.hero.herodiscription }}</p>
-		<a href="" class="button primary">{{ .Site.Params.hero.btnblue }}</a>
-		<a href="" class="button success">{{ .Site.Params.hero.btngreen }}</a>
+		{{ if isset .Site.Params.hero "btnblue" }}<a href="" class="button primary">{{ .Site.Params.hero.btnblue }}</a> {{ end }}
+                {{ if isset .Site.Params.hero "btngreen" }}<a href="" class="button success">{{ .Site.Params.hero.btngreen }}</a> {{ end }}
 	</div>
 </section> {{ "<!-- END HERO PANEL -->" | safeHTML }}


### PR DESCRIPTION
Hi

I realized that if you just don't specify the btngreen and btnblue parameters in the configuration file you can still see them. This should be enough to be able to remove it. I also see that you don't have the option of specifying the url for these buttons. I could provide a pull request for this as well. 

Thanks

Jose Monsalve